### PR TITLE
Fix executing Windows commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+
+# Editors
+.idea

--- a/index.js
+++ b/index.js
@@ -124,9 +124,7 @@ fashionShow.run = function (options, callback) {
       };
 
       // If there's no file extension under Windows, look for a .bat or .cmd equivalent
-      console.log(absolute.command);
       if (/^win/i.test(os.platform()) && !/[\\/][^\\/]*\.[^\\/]+$/.test(absolute.command)) {
-        console.log('Has no extension');
         if (fs.existsSync(absolute.command + '.cmd')) {
           absolute.command += '.cmd';
         } else if (fs.existsSync(absolute.command + '.bat')) {

--- a/index.js
+++ b/index.js
@@ -1,4 +1,5 @@
-var fs = require('fs'),
+var os = require('os'),
+    fs = require('fs'),
     path = require('path'),
     spawn = require('child_process').spawn,
     async = require('async'),
@@ -121,6 +122,17 @@ fashionShow.run = function (options, callback) {
         //
         options: { cwd: process.cwd() }
       };
+
+      // If there's no file extension under Windows, look for a .bat or .cmd equivalent
+      console.log(absolute.command);
+      if (/^win/i.test(os.platform()) && !/[\\/][^\\/]*\.[^\\/]+$/.test(absolute.command)) {
+        console.log('Has no extension');
+        if (fs.existsSync(absolute.command + '.cmd')) {
+          absolute.command += '.cmd';
+        } else if (fs.existsSync(absolute.command + '.bat')) {
+          absolute.command += '.bat';
+        }
+      }
 
       Object.keys(absolute).forEach(function (key) {
         debug(key, absolute[key]);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fashion-show",
-  "version": "2.0.1",
+  "version": "2.0.2",
   "description": "Build consistent and versioned styleguides by including and running consistent lint files across projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
`process.spawn` cannot launch shell scripts. Generally tools like `jscs` install a `.cmd` version of the command in parallel to shell scripts. This change looks for `.cmd` or `.bat` files in the binaries directory for Windows.