### PR TITLE
Bugfix for --reporter/--format and support absolute paths to linters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,4 @@ node_modules
 
 # Users Environment Variables
 .lock-wscript
+*.swp

--- a/lib/argify.js
+++ b/lib/argify.js
@@ -12,11 +12,12 @@ var argify = module.exports = function (command, opts) {
   if (!opts || !opts.targets || !opts.targets.length) {
     throw new Error('opts and opts.targets are required');
   }
+  var basename = path.basename(command);
 
-  var config = ['-c', path.join(opts.rc || '', '.' + command + 'rc')];
+  var config = ['-c', path.join(opts.rc || '', '.' + basename + 'rc')];
   debug('config', config);
 
-  var extended = argify[command](opts);
+  var extended = argify[basename](opts);
   debug('lint-specific', extended);
 
   return config
@@ -32,7 +33,7 @@ var argify = module.exports = function (command, opts) {
 argify.jscs = function (opts) {
   return [
     opts.fix      && '--fix',
-    opts.reporter && '--reporter ' + opts.reporter
+    opts.reporter && '--reporter=' + opts.reporter
   ].filter(Boolean);
 };
 
@@ -46,7 +47,8 @@ argify.eslint = function (opts) {
     //
     // TODO: Support opts.ext and opts.global
     //
-    opts.reporter && '--reporter ' + opts.reporter
+    // eslint doesn't have a "--reporter" option, but has a "--format" option
+    opts.format && '--format=' + opts.format
   ].filter(Boolean);
 };
 
@@ -60,6 +62,6 @@ argify.jshint = function (opts) {
     //
     // TODO: Support opts.ext and opts.global
     //
-    opts.reporter && '--reporter ' + opts.reporter
+    opts.reporter && '--reporter=' + opts.reporter
   ].filter(Boolean);
 };

--- a/lib/defaultify.js
+++ b/lib/defaultify.js
@@ -42,6 +42,7 @@ module.exports = function defaultify(defaults) {
     cwd:      argv.cwd      || defaults.cwd || process.cwd(),
     fix:      argv.fix      || defaults.fix,
     reporter: argv.reporter || defaults.reporter,
+    format:   argv.format   || defaults.format,
     global:   argv.global   || defaults.global,
     exts: ['.js']
       .concat(argv.ext      || [])

--- a/lib/printify.js
+++ b/lib/printify.js
@@ -28,8 +28,8 @@ module.exports = function printify(lint, options) {
         : chalk.cyan(arg);
     }).join(' ');
 
-  var targets = options.targets.map(function (dir) {
-    return (dir + '/').replace(/\/\/$/, '/');
+  var targets = options.targets.map(function (path) {
+    return path.replace(/\/\/$/, '/');
   }).join(' ');
 
   console.log('Running %s with options: %s %s', chalk.white.bold(lint.bin),

--- a/package.json
+++ b/package.json
@@ -37,9 +37,9 @@
   },
   "devDependencies": {
     "assume": "^1.2.6",
-    "eslint": "^1.0.0",
+    "eslint": "^1.3.1",
     "istanbul": "^0.3.17",
-    "jscs": "^2.0.0",
+    "jscs": "^2.1.1",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
     "mocha-istanbul": "^0.2.0",


### PR DESCRIPTION
Problem with `--reporter` was it called `jscs "--reporter inline"` where there was a space in argv[1] and not actually two args.  Also eslint doesn't support `--reporter`.   I removed the trailing slash from printouts because it looks funny when you call the linter on a single file.