### PR TITLE
Run .CMD files on Windows.

### DIFF
--- a/lib/run.js
+++ b/lib/run.js
@@ -44,6 +44,11 @@ module.exports = function run(command, options, callback) {
   //
   lint.options.env = envify(options);
 
+  // Run the .CMD executible on Windows.
+  if (/^win/.test(process.platform)) {
+    lint.bin = lint.bin + '.CMD';
+  }
+
   var child = spawn(lint.bin, lint.args, lint.options);
   printify(lint, options);
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "fashion-show",
-  "version": "3.3.1",
+  "version": "3.3.2",
   "description": "Build consistent and versioned styleguides by including and running consistent lint files across projects.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Running on Windows was returning file not found errors `Error: spawn jscs ENOENT`. 
- Appending command with .CMD for windows compatibility.

This also will resolve issue seen on GoDaddy Style project https://github.com/godaddy/javascript/issues/16
